### PR TITLE
Use sandpaper and varnish config keys to specify engine

### DIFF
--- a/.github/workflows/sandpaper-main.yaml
+++ b/.github/workflows/sandpaper-main.yaml
@@ -53,12 +53,12 @@ jobs:
             curl -o ~/.pandoc/templates/eisvogel.latex https://raw.githubusercontent.com/Wandmalfarbe/pandoc-latex-template/master/eisvogel.tex   
 
       - name: "Setup Lesson Engine"
-        uses: LearnToDiscover/actions/setup-sandpaper@main
+        uses: carpentries/actions/setup-sandpaper@main
         with:
           cache-version: ${{ secrets.CACHE_VERSION }}-test
 
       - name: "Setup Package Cache"
-        uses: LearnToDiscover/actions/setup-lesson-deps@main
+        uses: carpentries/actions/setup-lesson-deps@main
         with:
           cache-version: ${{ secrets.CACHE_VERSION }}-test
       - name: "Deploy Site"

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,8 @@
 # lc: Library Carpentry
 # cp: Carpentries (to use for instructor traning for instance)
 carpentry: l2d
+varnish: LearnToDiscover/varnish
+sandpaper: LearnToDiscover/sandpaper@l2d
 
 # Overall title for pages.
 title: Data Frames in Python


### PR DESCRIPTION
I'm really impressed with this repo (you got python integration to work!) and I wanted to help reduce the complexity needed to get this lesson (and future lessons) set up and running with the l2d versions of sandpaper and varnish. 

I released https://github.com/carpentries/actions/releases/tag/v0.8, which allows users to pin the versions of sandpaper and varnish on github using keys in the config.yaml. 

Let me know if this works for you 😸 